### PR TITLE
Add link to se AUR package

### DIFF
--- a/platforms.html
+++ b/platforms.html
@@ -48,7 +48,7 @@ cellspacing="0" cellpadding="4">
 </thead>
 <tbody>
 <tr>
-<td align="left" valign="top"><p class="table"><a href="https://www.archlinux.org/">Arch Linux</a> 2013.03.01</p>
+<td align="left" valign="top"><p class="table"><a href="https://www.archlinux.org/">Arch Linux</a> 2013.03.01 (<a href="https://aur.archlinux.org/packages/se">AUR</a>)</p>
 <p class="table"><a href="http://www.debian.org/">Debian GNU/Linux</a> 7.0</p>
 <p class="table"><a href="http://fedoraproject.org/">Fedora</a> 18</p>
 <p class="table"><a href="http://www.gentoo.org/">Gentoo Linux</a> 13.0 (<a href="https://bugs.gentoo.org/460588">ebuild</a>)</p>


### PR DESCRIPTION
I submitted `se` to the Arch Linux [AUR](https://aur.archlinux.org/packages/se).